### PR TITLE
fix default addressfamily IPv4 for destination

### DIFF
--- a/ipvs.go
+++ b/ipvs.go
@@ -290,12 +290,10 @@ func assembleDestinationInterface(attrs []syscall.NetlinkRouteAttr) (*Destinatio
 	}
 
 	switch d.AddressFamily {
-	case "IPv4":
-		d.Address = (net.IP)(addr[:4]).String()
 	case "IPv6":
 		d.Address = (net.IP)(addr[:16]).String()
 	default:
-		return nil, fmt.Errorf("invalid IP address %v", addr)
+		d.Address = (net.IP)(addr[:4]).String()
 	}
 
 	return &d, nil


### PR DESCRIPTION
libipvs can not get the destination address family with kernels before 3.18.

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=6cff339bbd5f9eda7a5e8a521f91a88d046e6d0c